### PR TITLE
docs: 主页橱窗补 Irasutoya 配图板块(中英)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Humanize PPT读取了50多期TED演讲，先处理主线，听众获得感和讲
 [![humanize-ppt](https://img.shields.io/github/stars/LearnPrompt/humanize-ppt?style=flat&label=humanize-ppt)](https://github.com/LearnPrompt/humanize-ppt)
 [![Demo](https://img.shields.io/badge/demo-online-brightgreen)](https://learnprompt.github.io/humanize-ppt/)
 
+**Irasutoya 配图 · 给文章配一张会吐槽的图**
+
+文章里最值钱的那个判断，配一张说明书式的图就死了。
+
+这个skill把中文文章里的关键判断、流程和隐喻，变成白底、圆润、有梗图感的Irasutoya反应人物解释图：角色DNA定稿，三套主角按情绪选角，跨图不走形。交付的是配图方案和生图提示词，素材按いらすとや官方条款使用。
+
+[![irasutoya](https://img.shields.io/github/stars/LearnPrompt/carl-irasutoya-illustrations?style=flat&label=Irasutoya%20%E9%85%8D%E5%9B%BE)](https://github.com/LearnPrompt/carl-irasutoya-illustrations)
+
 **班门家族 · 一组以中国工匠命名的skills**
 
 我把反复被验证过的方法论,做成了一组以人物命名的skills。一个名字,一门手艺:

--- a/README_EN.md
+++ b/README_EN.md
@@ -58,6 +58,14 @@ Humanize PPT studied more than 50 TED talks and handles the narrative arc, audie
 [![humanize-ppt](https://img.shields.io/github/stars/LearnPrompt/humanize-ppt?style=flat&label=humanize-ppt)](https://github.com/LearnPrompt/humanize-ppt)
 [![Demo](https://img.shields.io/badge/demo-online-brightgreen)](https://learnprompt.github.io/humanize-ppt/)
 
+**Irasutoya Illustrations · Give your article a picture that talks back**
+
+The most valuable judgment in an article dies next to a manual-style diagram.
+
+This skill turns the key judgments, flows, and metaphors of a Chinese article into white-background, soft-rounded Irasutoya reaction-character explainers: character DNA locked, three lead characters cast by emotion, consistent across images. It delivers shot lists and image-generation prompts; assets follow the official Irasutoya terms.
+
+[![irasutoya](https://img.shields.io/github/stars/LearnPrompt/carl-irasutoya-illustrations?style=flat&label=Irasutoya)](https://github.com/LearnPrompt/carl-irasutoya-illustrations)
+
 **The Workshop Family · skills named after Chinese craftsmen**
 
 I package methodologies that survived real use into a family of person-named skills. One name, one craft:


### PR DESCRIPTION
新公开的 carl-irasutoya-illustrations 在主页 README 没有露出。本 PR 在 Humanize PPT 与班门家族之间插入 Irasutoya 配图板块,中英双版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)