### PR TITLE
fix: redirect legacy documentation paths

### DIFF
--- a/starlight/package.json
+++ b/starlight/package.json
@@ -8,6 +8,7 @@
     "build": "ASTRO_TELEMETRY_DISABLED=1 astro build",
     "build:pages": "DEPLOY_TARGET=github-pages ASTRO_TELEMETRY_DISABLED=1 astro build",
     "check:i18n": "node scripts/check-i18n-slice.mjs",
+    "check:legacy-redirects": "node scripts/check-legacy-redirects.mjs",
     "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview"
   },
   "dependencies": {

--- a/starlight/scripts/check-legacy-redirects.mjs
+++ b/starlight/scripts/check-legacy-redirects.mjs
@@ -1,0 +1,60 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+const scriptDirectory = fileURLToPath(new URL(".", import.meta.url));
+const repositoryDirectory = join(scriptDirectory, "..", "..");
+const vercelConfig = JSON.parse(
+  await readFile(join(repositoryDirectory, "vercel.json"), "utf8")
+);
+
+const expectedRedirects = [
+  {
+    source: "/zh-Hans/docs/:path*",
+    destination: "https://v1.learnprompt.pro/zh-Hans/docs/:path*",
+    statusCode: 301,
+  },
+  {
+    source: "/docs/:path*",
+    destination: "https://v1.learnprompt.pro/docs/:path*",
+    statusCode: 301,
+  },
+];
+
+for (const expected of expectedRedirects) {
+  const actual = (vercelConfig.redirects || []).find(
+    (redirect) => redirect.source === expected.source
+  );
+  if (
+    !actual ||
+    actual.destination !== expected.destination ||
+    actual.statusCode !== expected.statusCode
+  ) {
+    throw new Error(`Missing legacy redirect: ${expected.source}`);
+  }
+}
+
+const legacyPathnames = [
+  "/zh-Hans/docs/llm-agents/ai-town/",
+  "/zh-Hans/docs/stable-diffusion/installation/",
+  "/docs/stable-diffusion/sd-prompt-syntax/",
+  "/zh-Hans/docs/prompt-engineering/reducing-gpt-hallucinations/",
+];
+
+for (const pathname of legacyPathnames) {
+  const expectedPrefix = pathname.startsWith("/zh-Hans/docs/")
+    ? "/zh-Hans/docs/"
+    : "/docs/";
+  const redirect = expectedRedirects.find((item) =>
+    item.source.startsWith(expectedPrefix)
+  );
+  const destination = redirect.destination.replace(
+    ":path*",
+    pathname.slice(expectedPrefix.length)
+  );
+  if (destination !== `https://v1.learnprompt.pro${pathname}`) {
+    throw new Error(`Legacy path does not preserve its content path: ${pathname}`);
+  }
+}
+
+console.log("Legacy documentation redirects are configured.");

--- a/starlight/scripts/check-legacy-redirects.mjs
+++ b/starlight/scripts/check-legacy-redirects.mjs
@@ -10,8 +10,18 @@ const vercelConfig = JSON.parse(
 
 const expectedRedirects = [
   {
+    source: "/zh-Hans/docs/:path*/",
+    destination: "https://v1.learnprompt.pro/zh-Hans/docs/:path*/",
+    statusCode: 301,
+  },
+  {
     source: "/zh-Hans/docs/:path*",
     destination: "https://v1.learnprompt.pro/zh-Hans/docs/:path*",
+    statusCode: 301,
+  },
+  {
+    source: "/docs/:path*/",
+    destination: "https://v1.learnprompt.pro/docs/:path*/",
     statusCode: 301,
   },
   {
@@ -45,12 +55,13 @@ for (const pathname of legacyPathnames) {
   const expectedPrefix = pathname.startsWith("/zh-Hans/docs/")
     ? "/zh-Hans/docs/"
     : "/docs/";
-  const redirect = expectedRedirects.find((item) =>
-    item.source.startsWith(expectedPrefix)
+  const redirect = expectedRedirects.find(
+    (item) => item.source === `${expectedPrefix}:path*/`
   );
+  const preservedPath = pathname.slice(expectedPrefix.length, -1);
   const destination = redirect.destination.replace(
     ":path*",
-    pathname.slice(expectedPrefix.length)
+    preservedPath
   );
   if (destination !== `https://v1.learnprompt.pro${pathname}`) {
     throw new Error(`Legacy path does not preserve its content path: ${pathname}`);

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,18 @@
   "installCommand": "cd starlight && npm ci",
   "buildCommand": "cd starlight && npm run build",
   "outputDirectory": "starlight/dist",
+  "redirects": [
+    {
+      "source": "/zh-Hans/docs/:path*",
+      "destination": "https://v1.learnprompt.pro/zh-Hans/docs/:path*",
+      "statusCode": 301
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "https://v1.learnprompt.pro/docs/:path*",
+      "statusCode": 301
+    }
+  ],
   "headers": [
     {
       "source": "/_astro/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -5,8 +5,18 @@
   "outputDirectory": "starlight/dist",
   "redirects": [
     {
+      "source": "/zh-Hans/docs/:path*/",
+      "destination": "https://v1.learnprompt.pro/zh-Hans/docs/:path*/",
+      "statusCode": 301
+    },
+    {
       "source": "/zh-Hans/docs/:path*",
       "destination": "https://v1.learnprompt.pro/zh-Hans/docs/:path*",
+      "statusCode": 301
+    },
+    {
+      "source": "/docs/:path*/",
+      "destination": "https://v1.learnprompt.pro/docs/:path*/",
       "statusCode": 301
     },
     {


### PR DESCRIPTION
## What changed

Adds permanent, path-preserving redirects for the retired `/docs/` and `/zh-Hans/docs/` trees to their identical, still-live v1 pages.

## Why

High-traffic legacy pages currently return 404 on `www`, even though their original content remains available at the same path on `v1`. This fixes the broken migration path without sending visitors to unrelated pages.

## Validation

- `npm run check:legacy-redirects`
- `npm run build`
- `npm run check:i18n`
- `npm run build:pages`
- `EXPECTED_BASE=/LearnPrompt npm run check:i18n`

## Scope

No production deployment or merge is included.